### PR TITLE
Fix filtering when multiple articles has the same name

### DIFF
--- a/src/views/articles/articles.module.scss
+++ b/src/views/articles/articles.module.scss
@@ -1,6 +1,16 @@
 @import 'src/pages/variables';
 
 .articles {
+  .legend {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    padding: 0 1rem;
+    font-size: .7rem;
+    font-style: italic;
+    color: var(--primary-color);
+  }
   ul {
     list-style: none;
     display: flex;

--- a/src/views/articles/articles.test.tsx
+++ b/src/views/articles/articles.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import Articles from "@/views/articles/articles";
+import {fireEvent, render, screen} from "@testing-library/react";
+import {buildArticle} from "@/_helpers/builders/build-article";
+
+describe('Articles', () => {
+  it('displays all articles', () => {
+    const articles = [
+      buildArticle({title: 'an article', locales: []}),
+      buildArticle({title: 'another article', locales: []})
+    ]
+    render(<Articles articles={articles}/>)
+
+    screen.getByRole('listitem', {name: `${articles[0].locales[0]} - ${articles[0].title}`})
+    screen.getByRole('listitem', {name: `${articles[1].locales[0]} - ${articles[1].title}`})
+  })
+
+  const filterByTypes = (typeNames: string[]) => {
+    fireEvent.click(screen.getByRole('button', {name: 'components.filter.text'}))
+    typeNames.forEach(typeName => fireEvent.click(screen.getByRole('checkbox', {name: typeName})))
+  };
+
+  it('displays articles filtered by type', () => {
+    const articles = [
+      buildArticle({title: 'an article', locales: [], type: 'Talk'}),
+      buildArticle({title: 'another article', locales: [], type: 'Post'})
+    ]
+    render(<Articles articles={articles}/>)
+    filterByTypes(['types.talk']);
+
+    screen.getByRole('listitem', {name: `${articles[0].locales[0]} - ${articles[0].title}`})
+    expect(screen.queryByRole('listitem', {name: `${articles[1].locales[0]} - ${articles[1].title}`})).not.toBeInTheDocument()
+  });
+
+  it('displays articles filtered by text', () => {
+    const articles = [
+      buildArticle({title: 'an article', locales: [], type: 'Talk'}),
+      buildArticle({title: 'another article', locales: [], type: 'Post'})
+    ]
+    render(<Articles articles={articles}/>)
+    fireEvent.change(screen.getByPlaceholderText('components.search.placeholder'), {target: {value: 'another'}})
+
+    screen.getByRole('listitem', {name: `${articles[1].locales[0]} - ${articles[1].title}`})
+    expect(screen.queryByRole('listitem', {name: `${articles[0].locales[0]} - ${articles[0].title}`})).not.toBeInTheDocument()
+  });
+
+})

--- a/src/views/articles/articles.tsx
+++ b/src/views/articles/articles.tsx
@@ -63,9 +63,10 @@ export const Articles: React.FC<ArticlesProps> = ({articles = []}) => {
       </Head>
       <SearchBar types={['Post', 'Talk']} onChangeSelectedTypes={setSelectedTypes} onChangeFilter={handleFilterChange}/>
       <section className={styles.articles}>
+        <span className={styles.legend}>{filteredArticles.length}/{articles.length} {t('articles')}</span>
         <ul>
           {filteredArticles.sort(sortArticlesByDate).reverse().map((article) => (
-            <li key={article.title}>
+            <li key={`${article.locales[0]}-${article.title}`} aria-label={`${article.locales[0]} - ${article.title}`}>
               <a
                 href={article.link}
                 target={article.external ? '_blank' : ''}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "jsx": "react"
-  }
-}


### PR DESCRIPTION
We have found a bug related to the data translation. In order that now we can have multiple articles with the same name, we need to introduce the locale definition at key in order that rerender will works properly.